### PR TITLE
Option in GUI for "log authentication failures"

### DIFF
--- a/modules/sipinterface-1.0.2/libraries/drivers/freeswitch/sipinterface.php
+++ b/modules/sipinterface-1.0.2/libraries/drivers/freeswitch/sipinterface.php
@@ -232,6 +232,16 @@ class FreeSwitch_SipInterface_Driver extends FreeSwitch_Base_Driver
             $xml->deleteNode('/settings/param[@name="NDLB-force-rport"]');
         }
 
+        // Enable log auth failures by default.
+        if (arr::get($base, 'registry', 'log_auth_failures'))
+        {
+            $xml->update('/settings/param[@name="log-auth-failures"]{@value="true"}');
+        }
+        else
+        {
+            $xml->deleteNode('/settings/param[@name="log-auth-failures"]');
+        }
+
         // Enable compact headers by default. With all the Codecs FS now supports we see lots of
         // bad behavior re: UDP packets that are too large and get fragmented
         if (arr::get($base, 'registry', 'compact_headers'))

--- a/modules/sipinterface-1.0.2/views/sipinterface/update.php
+++ b/modules/sipinterface-1.0.2/views/sipinterface/update.php
@@ -43,6 +43,15 @@
 
         <div class="field">
         <?php
+            echo form::label(array('for' => 'sipinterface[registry][log_auth_failures]',
+                                   'help' => 'Write to logfile when authentication fails (e.g. wrong login/pass). Used by fail2ban',
+                                   ), 'Log authentication failures:');
+            echo form::checkbox('sipinterface[registry][log_auth_failures]');
+        ?>
+        </div>
+
+        <div class="field">
+        <?php
             echo form::label(array('for' => 'sipinterface[registry][compact_headers]',
                                    'help' => 'Use SIP-compliant compact headers. Useful to fix broken UDP, where the packets are exceeding the size the router allows'
                                    ), 'Use Compact Headers:');


### PR DESCRIPTION
This allows the operator to mark a particular SIP trunk as "log authentication failures" - this means a program like fail2ban can block naughty people trying to brute-force their way in to your PBX
