### PR TITLE
Fixes BLUEBOX-306 - simpleroute bugfix for gaps in patterns

### DIFF
--- a/modules/simpleroute-1.1/controllers/simpleroute.php
+++ b/modules/simpleroute-1.1/controllers/simpleroute.php
@@ -99,7 +99,7 @@ class SimpleRoute_Controller extends Bluebox_Controller
             throw new Exception('You must provide at least one pattern');
         }
 
-        $object['patterns'] = $patterns;
+        $object['patterns'] = array_values($patterns);
 
         parent::pre_save($object);
     }


### PR DESCRIPTION
simpleroute is easily confused if it loads back a list of patterns with gaps in it. This fixes that problem.
