### PR TITLE
Fixes BLUEBOX-228 - Fix Multiple regex's in simpleroute

### DIFF
--- a/modules/simpleroute-1.1/helpers/simplerouter.php
+++ b/modules/simpleroute-1.1/helpers/simplerouter.php
@@ -37,20 +37,27 @@ class simplerouter
         {
             case 'freeswitch':
                 // Loop each rule and build a regex
-                $pattern = '';
+                $pattern = Array();
 
                 foreach ($patterns as $rule)
                 {
                     if (!$convert)
                     {
-                        $pattern .= $rule .'|';
+                        array_push($pattern, $rule);
 
                         continue;
                     }
 
                     if (preg_match('/^[0-9]*$/', $rule))
                     {
-                        $pattern .= '^' . $rule . '$|';
+			if (preg_match('/\(/',$rule)) 
+			{
+	                        array_push($pattern, '^' . $rule . '$');
+			} 
+			else 
+			{
+				array_push($pattern, '^(' . $rule . ')$');
+			}
 
                         continue;
                     }
@@ -63,12 +70,19 @@ class simplerouter
                     }
                     
                     // Convert the short hand into regex
-                    $pattern .= '^' . $rule . '$|';
+		    if (preg_match('/\(/',$rule)) 
+		    {
+			array_push($pattern, '^' . $rule . '$');
+		    } 
+		    else 
+		    {
+			array_push($pattern, '^(' . $rule . ')$');
+		    }
                 }
 
                 // we added a pipe on the end of every rule so remove the last one
                 //$pattern = str_replace(array('{', '}'), array('\{', '\}'), $pattern);
-                return rtrim($pattern, '|');
+                return $pattern;
                 
             case 'asterisk':
                 // Loop each rule and build a regex

--- a/modules/simpleroute-1.1/libraries/drivers/freeswitch/simpleroute.php
+++ b/modules/simpleroute-1.1/libraries/drivers/freeswitch/simpleroute.php
@@ -41,16 +41,20 @@ class FreeSwitch_SimpleRoute_Driver extends FreeSwitch_Base_Driver
 
                 $xml->deleteChildren();
 
-                $condition = '/condition[@field="destination_number"][@expression="' .$pattern . '"][@bluebox="pattern_' .$simple_route_id .'"]';
+		foreach (array_keys($pattern) AS $pattern_index) 
+		{
 
-                if (!empty($options['prepend']))
-                {
-                    $xml->update($condition .'/action[@application="set"][@bluebox="prepend"]{@data="prepend=' . $options['prepend'] . '"}');
-                }
-                else
-                {
-                    $xml->update($condition .'/action[@application="set"][@bluebox="prepend"]{@data="prepend="}');
-                }
+	                $condition = '/condition[@field="destination_number"][@break="never"][@expression="' .$pattern[$pattern_index] . '"][@bluebox="pattern_' .$simple_route_id . '_part_' . ($pattern_index+1) .'"]';
+
+	                if (!empty($options['prepend']))
+	                {
+	                    $xml->update($condition .'/action[@application="set"][@bluebox="prepend"]{@data="prepend=' . $options['prepend'] . '"}');
+	                }
+	                else
+	                {
+	                    $xml->update($condition .'/action[@application="set"][@bluebox="prepend"]{@data="prepend="}');
+	                }
+		}
 
                 if (!empty($simpleroute['caller_id_name']))
                 {
@@ -80,18 +84,21 @@ class FreeSwitch_SimpleRoute_Driver extends FreeSwitch_Base_Driver
                     }
                 }
 
-                $dummy = '/condition[@field="destination_number"][@expression="' . $pattern . '"][@bluebox="pattern_' .$simple_route_id .'_out"]';
-
-                if (!empty($simpleroute['continue_on_fail']))
+		foreach (array_keys($pattern) AS $pattern_index) 
                 {
-                    $xml->update($dummy .'/action[@application="set"][@bluebox="setting_continue_on_fail"]{@data="failure_causes=NORMAL_CLEARING,ORIGINATOR_CANCEL,CRASH"}');
-                }
-                else
-                {
-                    $xml->deleteNode($dummy .'/action[@application="set"][@bluebox="setting_continue_on_fail"]');
-                }
+	                $dummy = '/condition[@field="destination_number"][@break="never"][@expression="' . $pattern[$pattern_index] . '"][@bluebox="pattern_' .$simple_route_id . '_part_' . ($pattern_index+1) .'_out"]';
 
-                $xml->update($dummy . '/action[@application="bridge"][@bluebox="out_trunk_' .$base['trunk_id'] .'"]{@data="sofia\/gateway\/trunk_' .$base['trunk_id'] . '\/${prepend}$1"}');
+	                if (!empty($simpleroute['continue_on_fail']))
+	                {
+	                    $xml->update($dummy .'/action[@application="set"][@bluebox="setting_continue_on_fail"]{@data="failure_causes=NORMAL_CLEARING,ORIGINATOR_CANCEL,CRASH"}');
+	                }
+	                else
+	                {
+	                    $xml->deleteNode($dummy .'/action[@application="set"][@bluebox="setting_continue_on_fail"]');
+	                }
+
+	                $xml->update($dummy . '/action[@application="bridge"][@bluebox="out_trunk_' .$base['trunk_id'] .'"]{@data="sofia\/gateway\/trunk_' .$base['trunk_id'] . '\/${prepend}$1"}');
+		}
             }
         }
     }


### PR DESCRIPTION
Combining regexes (regii?) is _very_ complicated, if not impossible. This gets around the problem by leaving them seperate, and having multiple rules to compensate.

Also, if you put in a non-regex pattern with brackets, it puts brackets around the entire thing. The number that is dialed is always $1, so it doesn't make any sense to have a pattern of '1234' - it will forward the call with a number of ''.
