### PR TITLE
Ensure new extensions get added after the END of the section.

### DIFF
--- a/modules/freeswitch-1.1.1/libraries/FreeSwitch.php
+++ b/modules/freeswitch-1.1.1/libraries/FreeSwitch.php
@@ -607,11 +607,11 @@ class FreeSwitch extends Telephony_Driver
             $insert_position = array_search($section, $sections);
 
             // Keep going up the document from the bottom until we find the right section
-            while ($insert_position > 0 and ($elements->length == 0))
+            while ($insert_position >= 0 and ($elements->length == 0))
             {
-                $insert_position--;
-                
                 $elements = $xp->query('//document/section[@name="dialplan"]/context[@name="' . $context . '"]/extension[starts-with(@name,"' . $sections[$insert_position] . '_")]');
+
+                $insert_position--;
             }
 
             $newNode = self::$instance->xml->createElement('extension');
@@ -621,7 +621,7 @@ class FreeSwitch extends Telephony_Driver
             $newNode->setAttribute('continue', 'true');
 
             // Did we fail at finding the right place to insert? If so, just insert at the top
-            if ($insert_position == 0)
+            if ($insert_position < 0)
             {
                 Kohana::log('debug', 'FreeSWITCH -> Adding ' . $section . '_' . $extensionName . ' at top of context ' . $context);
                 


### PR DESCRIPTION
Previously, it would be added after the end of the section ABOVE it - i.e. before the start of the section you want.

Fixes http://tickets.2600hz.org/browse/BLUEBOX-320
