### PR TITLE
If a table has a auto-increment PK, it must be used.

### DIFF
--- a/modules/maintenance-1.0/libraries/Maintenance.php
+++ b/modules/maintenance-1.0/libraries/Maintenance.php
@@ -9,8 +9,6 @@ class Maintenance
         if (!$maintenance_event)
         {
             $maintenance_event = new MaintenanceEvent;
-
-            $maintenance_event['maintenance_event_id'] = 1;
         }
 
         $maintenance_event['last_run'] = time();


### PR DESCRIPTION
specifying that your table has an auto-incrementing primary key, and then specifying that your table has an auto-incrementing primary key, and then creating a new record with a hard-coded value breaks Postgres. It is also quite pointless. If there can only be one record with one possible value, (a) what's the point of having it an auto-incrementing value, and (b) what's the point of having that column at all? You don't need a PK to find the only record there can be.

In any case, this removes the hard-coded value, lets the PK get pulled from the sequence (which should start at one).
