### PR TITLE
if you save a record which contains a text edit field which has '0' in it, next time you edit it, it will be blank.

### DIFF
--- a/bluebox/helpers/Bluebox_form.php
+++ b/bluebox/helpers/Bluebox_form.php
@@ -1288,13 +1288,13 @@ class form extends form_Core
 
             $viewVar = arr::smart_cast($viewVar);
 
-            if (($viewValue = arr::get_string($viewVar, $name, TRUE)))
+            if (!is_null($viewValue = arr::get_string($viewVar, $name, TRUE)))
             {
                 return $viewValue;
             }
         }
 
-        if (($postValue = arr::get_string($_POST, $name)))
+        if (!is_null($postValue = arr::get_string($_POST, $name)))
         {
             return $postValue;
         }

--- a/modules/endpointmanager-1.2/configure.php
+++ b/modules/endpointmanager-1.2/configure.php
@@ -20,6 +20,7 @@ class EndpointManager_1_2_Configure extends Bluebox_Configure
     public static $navBranch = '/Applications/';
     public static $navURL = 'endpointmanager/index';
     public static $navSubmenu = array(
+	'Global Settings' => 'endpointmanager/settings',
         'Search Endpoints' => 'endpointmanager/index',
         'Add Endpoint' => 'endpointmanager/create',
         'Edit Endpoint' => array(

--- a/modules/endpointmanager-1.2/models/Endpoint.php
+++ b/modules/endpointmanager-1.2/models/Endpoint.php
@@ -10,7 +10,7 @@ class Endpoint extends Bluebox_Record
         // COLUMN DEFINITIONS
 	$this->hasColumn('endpoint_id', 'integer', 11, array('unsigned' => true, 'primary' => true, 'autoincrement' => true));
 	$this->hasColumn('name','string',512);
-	$this->hasColumn('mac','string',12,array('notnull'=>true,'notblank'=>true));
+	$this->hasColumn('mac','string',12,array('notnull'=>true,'notblank'=>true,'unique'=>true));
 	$this->hasColumn('brand','string',30,array('notnull'=>true,'notblank'=>true));
 	$this->hasColumn('model','string',30,array('notnull'=>true,'notblank'=>true));
 	$this->hasColumn('settings','string');

--- a/modules/endpointmanager-1.2/views/endpointmanager/settings.php
+++ b/modules/endpointmanager-1.2/views/endpointmanager/settings.php
@@ -8,6 +8,7 @@
 	<?php echo form::open(); ?>
 
 	<?php echo form::open_section('Global Settings'); ?>
+	<div class='field'>
 	<?php echo form::label(array(
 		'for'=>'package[registry][defaults][global][timezone]',
 		'hint'=>'Default timezone for all phones',
@@ -16,8 +17,11 @@
 
 		echo timezone::dropdown("package[registry][defaults][global][timezone]",$savedtimezone);
 	?>
+	</div>
 
 	<?php echo form::close_section(); ?>
+
+	<?php echo $additionalquestions; ?>
 
 	<?php echo form::close(TRUE); ?>
 </div>


### PR DESCRIPTION
Currently, if you save a record which contains a text edit field which has '0' in it, next time you edit it, it will be blank.

To reproduce, create or edit a device, fill in all the fields, and set the device name to 0. save it, then go back in and edit it - the field is no longer 0, it is blank.

This is not a problem in many cases, since few people call their device '0'. However, if someone wants to set the VLAN for an endpoint, the default vlan is 0, which won't show up next time you edit it.

See http://tickets.2600hz.org/browse/BLUEBOX-527
