### PR TITLE
if you save a record which contains a text edit field which has '0' in it, next time you edit it, it will be blank.

### DIFF
--- a/bluebox/helpers/Bluebox_form.php
+++ b/bluebox/helpers/Bluebox_form.php
@@ -1288,13 +1288,13 @@ class form extends form_Core
 
             $viewVar = arr::smart_cast($viewVar);
 
-            if (($viewValue = arr::get_string($viewVar, $name, TRUE)))
+            if (!is_null($viewValue = arr::get_string($viewVar, $name, TRUE)))
             {
                 return $viewValue;
             }
         }
 
-        if (($postValue = arr::get_string($_POST, $name)))
+        if (!is_null($postValue = arr::get_string($_POST, $name)))
         {
             return $postValue;
         }


### PR DESCRIPTION
Currently, if you save a record which contains a text edit field which has '0' in it, next time you edit it, it will be blank.

To reproduce, create or edit a device, fill in all the fields, and set the device name to 0. save it, then go back in and edit it - the field is no longer 0, it is blank.

This is not a problem in many cases, since few people call their device '0'. However, if someone wants to set the VLAN for an endpoint, the default vlan is 0, which won't show up next time you edit it.
