### PR TITLE
Fix error message in xmlcdr's xml report

### DIFF
--- a/modules/xmlcdr-2.0/controllers/xmlcdr.php
+++ b/modules/xmlcdr-2.0/controllers/xmlcdr.php
@@ -195,7 +195,7 @@ class Xmlcdr_Controller extends Bluebox_Controller {
 				echo "\n";
 			}
 		} else {
-			ob_end_clean();
+			ob_clean();
 			echo '<cdrs>' . "\n";
 			foreach ($exprecs as $exprec)
 			{


### PR DESCRIPTION
Before this fix, if you exported the call records as XML (the "else" clause"), ob_end_clean would be called, disabling the buffer. Then, immediately after the end of the "else" clause, ob_end_flush would be called. Since the buffer was disabled, ob_end_flush would generate an error message, which would be tacked on to the end of the xml report.

This change fixes this by replacing ob_end_clean with ob_clean, which also deletes the current contents of the buffer, but does not disable buffering.
