### PR TITLE
Fixed issue with SNOM 320 provisioning

### DIFF
--- a/modules/endpointmanager-1.2/controllers/endpointmanager.php
+++ b/modules/endpointmanager-1.2/controllers/endpointmanager.php
@@ -342,6 +342,7 @@ class EndpointManager_Controller extends Bluebox_Controller
 		exit;
 	} else {
         	$rd = $provisioner_lib->generate_all_files();
+                if($provisioner_lib->brand_name == 'snom') $file = strtolower($file);
         	if(array_key_exists($file, $rd)) {
 		    header("content-type: text/plain");
         	    print $rd[$file];


### PR DESCRIPTION
Provisioning of snom 320 model is not possible because mac address sent by device is lowercased by system and when device try to get configuration it gets 404 not found error. Fix curently tries to be non intrusive as possible - only looking into snom devices.
