### PR TITLE
Bug in simpleroute with empty vs isset 

### DIFF
--- a/modules/endpointmanager-1.2/controllers/endpointmanager.php
+++ b/modules/endpointmanager-1.2/controllers/endpointmanager.php
@@ -342,7 +342,6 @@ class EndpointManager_Controller extends Bluebox_Controller
 		exit;
 	} else {
         	$rd = $provisioner_lib->generate_all_files();
-                if($provisioner_lib->brand_name == 'snom') $file = strtolower($file);
         	if(array_key_exists($file, $rd)) {
 		    header("content-type: text/plain");
         	    print $rd[$file];

--- a/modules/endpointmanager-1.2/controllers/endpointmanager.php
+++ b/modules/endpointmanager-1.2/controllers/endpointmanager.php
@@ -342,6 +342,7 @@ class EndpointManager_Controller extends Bluebox_Controller
 		exit;
 	} else {
         	$rd = $provisioner_lib->generate_all_files();
+                if($provisioner_lib->brand_name == 'snom') $file = strtolower($file);
         	if(array_key_exists($file, $rd)) {
 		    header("content-type: text/plain");
         	    print $rd[$file];

--- a/modules/simpleroute-1.1/libraries/drivers/freeswitch/simpleroute.php
+++ b/modules/simpleroute-1.1/libraries/drivers/freeswitch/simpleroute.php
@@ -52,7 +52,7 @@ class FreeSwitch_SimpleRoute_Driver extends FreeSwitch_Base_Driver
 
                 $condition = '/condition[@field="destination_number"][@expression="' .$pattern_string . '"][@bluebox="pattern_' .$simple_route_id . '_parts"]';
 
-                if (!empty($options['prepend']))
+                if (isset($options['prepend']))
                 {
                     $xml->update($condition .'/action[@application="set"][@bluebox="prepend"]{@data="prepend=' . $options['prepend'] . '"}');
                 }


### PR DESCRIPTION
More info at http://php.net/manual/en/function.empty.php
in paragraph "Return Values" with empty it is not possible
to create "0" as prepend value
